### PR TITLE
Text to speech checks which device to play on to fix bug where TTS runs on both player's turns

### DIFF
--- a/StoryQuest/app/Gameplay/[roomId]/[storyTitle]/page.tsx
+++ b/StoryQuest/app/Gameplay/[roomId]/[storyTitle]/page.tsx
@@ -987,7 +987,7 @@ export default function Home() {
           </AnimatePresence>
 
           {/* Calls AutomaticTextToSpeech, which speech texts the current fill in the blank phrase*/}
-          {phrase && <TextToSpeechTextOnly key={phrase} text={phrase} playOverlay={showInitialPlayOverlay} />}
+          {playerNumber === currentTurn && phrase && <TextToSpeechTextOnly key={phrase} text={phrase} playOverlay={showInitialPlayOverlay} />}
 
           {showOverlay && (
             <div className="fixed inset-0 z-50 bg-black bg-opacity-80 flex items-center justify-center">


### PR DESCRIPTION
There was a bug where the line to narrate would play on every player's turns, even though it should have only narrated on the active player's turn. To fix this, we used the logic for tracking the player (playerNumber) along with tracking which whose current turn it is, to the code which calls the TTS.

In the line that calls the text to speech, an additional check for invoking it is added:
playerNumber == currentTurn 