### PR TITLE
Group 6: bugfix for multiple devices playing audio at the same time

### DIFF
--- a/StoryQuest/app/Gameplay/[roomId]/[storyTitle]/page.tsx
+++ b/StoryQuest/app/Gameplay/[roomId]/[storyTitle]/page.tsx
@@ -987,7 +987,9 @@ export default function Home() {
           </AnimatePresence>
 
           {/* Calls AutomaticTextToSpeech, which speech texts the current fill in the blank phrase*/}
-          {phrase && <TextToSpeechTextOnly key={phrase} text={phrase} playOverlay={showInitialPlayOverlay} />}
+          {phrase && (currentTurn === playerNumber) ? (
+            <TextToSpeechTextOnly key={phrase} text={phrase} playOverlay={showInitialPlayOverlay} />
+          ) : null}
 
           {showOverlay && (
             <div className="fixed inset-0 z-50 bg-black bg-opacity-80 flex items-center justify-center">

--- a/documentation/docs/requirements/use-case-descriptions.md
+++ b/documentation/docs/requirements/use-case-descriptions.md
@@ -72,7 +72,7 @@ Figure 2
 <details open="True">
 1. User joins a room. 
 2. User is presented with an AAC keyboard layout on the left of their screen during gameplay. 
-3. During their turn, the user can click AAC buttons. 
+3. During their turn, phrase is spoken and user can click AAC buttons. 
 4. When a button is clicked, its label is sent to the device’s speech synthesis engine. 
 5. The button’s label is read aloud using synthesized speech. 
 </details>
@@ -88,12 +88,21 @@ sequenceDiagram
     D ->>+ GR: Notify that user joined room
     GR -->> User: Display AAC keyboard layout
 
+    GR ->> D: Request player number
+    D -->> GR: Return player number
+
+    Note over GR: currentTurn == playerNumber
+    
+    GR ->>+ TTS: Send current phrase
+    TTS -->>- GR: Synthesized phrase audio
+    GR -->> User: Play phrase aloud
+
     Note over User,GR: During gameplay
 
     User ->> GR: Clicks an AAC button
     GR ->>+ TTS: Send label of clicked AAC button
-    TTS -->>- GR: Synthesized speech audio
-    GR -->> User: Play speech aloud
+    TTS -->>- GR: Synthesized word audio
+    GR -->> User: Play word aloud
 ```
 Figure 3
 ## Game Mechanics


### PR DESCRIPTION
Group 6: Fixing bug that causes voices to play from multiple devices. Initially created pull request with capstone repo, now added changes to this repo.

Changes were made to the logic that plays text-to-speech, now it only plays on the device of the player whose turn it is.

These fixes worked perfectly on the capstone repo, but on this repo the AAC buttons don't seem to work (although this is the case even with the cloned repo). Still, audio only plays on one device, so our change seems to be working.

Tested by playing the game locally after each attempted changes.